### PR TITLE
Fix experience layout issue #3

### DIFF
--- a/client/src/components/Experience/Experience.css
+++ b/client/src/components/Experience/Experience.css
@@ -24,6 +24,12 @@
     padding-left:0;
 }
 
+div .icon,
+div .description {
+  max-width: max-content;
+  min-width: max-content;
+}
+
 /* If the screen size is 601px wide or more, set the font-size of <div> to 80px */
 @media screen and (min-width: 601px) {
     div.example {
@@ -35,5 +41,14 @@
   @media screen and (max-width: 600px) {
     div.example {
       font-size: 30px;
+    }
+  }
+
+  @media screen and (max-width: 450px) {
+    div .icon,
+    div .description {
+      min-width: 100%;
+      margin-bottom: 15px;
+      text-align: center;
     }
   }

--- a/client/src/components/Experience/Experience.js
+++ b/client/src/components/Experience/Experience.js
@@ -7,8 +7,8 @@ function Experience (){
         <div className="div4 pt-5"> 
         <h2 style={{"font-family": 'Crete Round, serif', 'font-size': '48px'}}className='text-center'>Experience</h2>
             <div className='container pt-5'>
-                <div className='row no-gutters' >
-                    <div className='col'>
+                <div className='row no-gutters justify-content-center flex-wrap' >
+                    <div className='col icon'>
                         <img
                             src={img}
                             height='35px'
@@ -16,7 +16,7 @@ function Experience (){
                         >
                         </img>
                     </div>
-                    <div className='col'>
+                    <div className='col description'>
                         <p> Tata Consultancy Services</p>
                         <p>Nov 2020 - Present</p>
                     </div>


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes issue #3 . 

Hello, I came across this issue while browsing github, and had some suggestions on how to improve the layout and make it responsive! 

**Standard layout**
<img width="807" alt="Screen Shot 2021-11-12 at 12 11 20 PM" src="https://user-images.githubusercontent.com/84106309/141498554-717f846e-1eae-492d-8008-688987049f2a.png">

**Layout on small viewports**
<img width="438" alt="Screen Shot 2021-11-12 at 12 11 31 PM" src="https://user-images.githubusercontent.com/84106309/141498638-73352b1b-e03d-4015-9667-39fab24d8224.png">

